### PR TITLE
Added autofocus to title field; enabled tabbing for codemirror fields

### DIFF
--- a/src/components/EditorMadr.vue
+++ b/src/components/EditorMadr.vue
@@ -21,12 +21,11 @@
                         filled
                         dense
                         placeholder="Title"
-                        hint="Changing the title, changes the file name. Do not use special characters."
+                        :autofocus="true"
+                        hint="Changing the title changes the file name. Do not use special characters."
                         v-model="adr.title"
                         @input="$emit('input', adr)"
-                        style="font-family: Roboto, sans-serif;
-        font-size: 28px;
-        font-weight: 500"
+                        style="font-family: Roboto, sans-serif; font-size: 28px; font-weight: 500"
                     >
                         <template v-slot:append="">
                             <HelpIcon>
@@ -145,7 +144,6 @@
 </template>
 
 <script>
-//import _ from 'lodash'
 import { ArchitecturalDecisionRecord } from "@/plugins/classes.js";
 import { store } from "@/plugins/store.js";
 

--- a/src/components/EditorMadrCodemirror.vue
+++ b/src/components/EditorMadrCodemirror.vue
@@ -54,7 +54,8 @@ export default {
                 connect: "align",
                 lineWrapping: true,
                 mode: "text/x-markdown",
-                lineNumbers: false
+                lineNumbers: false,
+                extraKeys: { Tab: false, "Shift-Tab": false }
             },
 
             isVisible: true,


### PR DESCRIPTION
Fixes #127 and #128

Two fields are still not included in the tabbing since they are a DatePicker and a Dropdown (last update and ADR status). These two may need to be investigated in the future. 